### PR TITLE
Fail fast when POSTGRES_URL is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ _Response:_
 ## How to Run
 
 > **Set the `POSTGRES_URL` environment variable to point to your PostgreSQL instance**
+> The application raises a `RuntimeError` at startup if this variable is missing.
 
 Example:
 ```bash

--- a/cladecanvas/db.py
+++ b/cladecanvas/db.py
@@ -6,10 +6,19 @@ from dotenv import load_dotenv
 # Load from .env file if present
 load_dotenv()
 
+"""Database connection setup for CladeCanvas."""
+
+# Default to no URL so we can detect a misconfiguration.
 DEFAULT_DB_URL = ""
 
-# Use env var or fallback
+# Use environment variable if provided
 DB_URL = os.environ.get("POSTGRES_URL", DEFAULT_DB_URL)
+
+if not DB_URL:
+    raise RuntimeError(
+        "POSTGRES_URL environment variable not set. "
+        "Please provide a valid SQLAlchemy database URL."
+    )
 
 # SQLAlchemy engine and session factory
 engine = create_engine(DB_URL, echo=False)


### PR DESCRIPTION
## Summary
- raise RuntimeError in db module if POSTGRES_URL environment variable not set, clarifying configuration issues
- document that the application errors on startup when POSTGRES_URL is missing

## Testing
- `PYTHONPATH=. POSTGRES_URL=sqlite:///:memory: pytest tests/test_fetch.py -q`
- `PYTHONPATH=. POSTGRES_URL=sqlite:///:memory: pytest -q` (fails: no such table: nodes)


------
https://chatgpt.com/codex/tasks/task_e_6875fe9d93648326a67ae1a5cf5f436e